### PR TITLE
disable health-check when not replacing kubeproxy

### DIFF
--- a/charts/internal/cilium/charts/config/templates/configmap.yaml
+++ b/charts/internal/cilium/charts/config/templates/configmap.yaml
@@ -538,6 +538,8 @@ data:
 {{- end }}
 {{- if hasKey .Values "healthChecking" }}
   enable-health-checking: {{ .Values.healthChecking | quote }}
+{{- else if or (or (eq .Values.global.kubeProxyReplacement "false") (eq .Values.global.kubeProxyReplacement "partial")) (eq .Values.global.kubeProxyReplacement "disabled") }}
+  enable-health-checking: "false"
 {{- end }}
 {{- if .Values.global.wellKnownIdentities.enabled }}
   enable-well-known-identities: "true"


### PR DESCRIPTION
According to https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/, health checking must be disabled, if not replacing kube-proxy. Respect this in the config map.

Details from doc:
kubeProxyReplacement=false: This option is used to disable any Kubernetes service handling by fully relying on kube-proxy instead, except for ClusterIP services accessed from pods (pre-v1.6 behavior), or for a hybrid setup. That is, kube-proxy is running in the Kubernetes cluster where Cilium partially replaces and optimizes kube-proxy functionality. The false option requires the user to manually specify which components for the eBPF kube-proxy replacement should be used. Similarly to true mode, the Cilium agent will bail out on start-up with an error message if the underlying kernel requirements are not met when components are manually enabled. For fine-grained configuration, socketLB.enabled, nodePort.enabled, externalIPs.enabled and hostPort.enabled can be set to true. By default all four options are set to false. If you are setting nodePort.enabled to true, make sure to also set nodePort.enableHealthCheck to false, so that the Cilium agent does not start the NodePort health check server (kube-proxy will also attempt to start this server, and there would otherwise be a clash when cilium attempts to bind its server to the same port). A few example configurations for the false option are provided below.

**How to categorize this PR?**
<!--
/area quality
/kind enhancement


For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

**What this PR does / why we need it**:
This ensures correct configuration and helps avoiding pitfalls for users.

**Which issue(s) this PR fixes**:
This is a quality of life feature.

**Special notes for your reviewer**:

**Release note**:
feature user

